### PR TITLE
未指定 -s 时自动在 build/ 文件夹查找 sln 文件。解析 cpp 标准，未指定 cpp 标准时默认 cpp20。默认配置从 Debug|Win32 改为 Debug|x64。添加 go-releaser 自动发布。

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,34 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          # 'latest', 'nightly', or a semver
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,59 @@
-
 # vs_export
-read visual studio 15/17/19/22 sln file,export clang compile_commands.json
+
+A tool to generate `compile_commands.json` from Visual Studio solution files (VS2015/2017/2019/2022).
+
+## Usage
+
+```bash
+vs_export [-s <path>] -c <configuration>
+
+Options:
+    -s  <path>          Path to .sln file (optional, auto-detect in build/ if not specified)
+    -c  <configuration> Build configuration (e.g., "Debug|x64", default: "Debug|x64")
+```
+
+## Examples
+
+### With CMake Project
+
+If your project uses CMake, simply:
+1. Generate VS solution
+2. Run vs_export
+```bash
+cmake -S . -B build
+vs_export
+```
+
+### Manual Usage
+
+For non-CMake projects or when you need specific configuration:
+```bash
+vs_export -s MyProject.sln -c "Release|x64"
+```
+
+## Output
+
+The tool generates a `compile_commands.json` file that is compatible with:
+- clangd
+- ccls
+- Other LSP (Language Server Protocol) servers
+- Various C++ analysis tools
+
+## Alternative Method
+
+If you're using CMake with Ninja generator, you can get `compile_commands.json` directly:
+```bash
+cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+cmake --build build
+```
+
+## Why vs_export?
+
+- Simple to use
+- Works with existing Visual Studio solutions
+- No need to modify project files
+- Supports modern Visual Studio versions
+- Automatic solution file detection
 
 ```cmd
 Usage: vs_export -s <path> -c <configuration>
@@ -10,11 +63,3 @@ Where:
             -c   configuration               project configuration,eg Debug|Win32.
                                              default Debug|Win32
 ```
-
-## example
-
-```cmd
-vs_export.exe  -s NYWinHotspot.sln  -c "Debug|x64"
-```
-
-this can export a compile_commands.json. the compile_commands.json can used by clangd or ccls or some other cpp language server.

--- a/main.go
+++ b/main.go
@@ -19,20 +19,17 @@ func main() {
 	if slnPath == "" {
 		// 在build目录下查找sln文件
 		buildDir := "build"
-		err := filepath.Walk(buildDir, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if !info.IsDir() && filepath.Ext(path) == ".sln" {
-				slnPath = path
-				return filepath.SkipAll
-			}
-			return nil
-		})
-
+		files, err := os.ReadDir(buildDir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "查找sln文件时出错: %v\n", err)
 			os.Exit(1)
+		}
+
+		for _, file := range files {
+			if !file.IsDir() && filepath.Ext(file.Name()) == ".sln" {
+				slnPath = filepath.Join(buildDir, file.Name())
+				break
+			}
 		}
 
 		if slnPath == "" {

--- a/sln/project.go
+++ b/sln/project.go
@@ -184,17 +184,18 @@ func RemoveBadDefinition(def string) string {
 // 添加一个辅助函数来处理 C++ 标准
 func getCppStandardFlag(langStd string, conformance string) string {
 	// 只处理语言标准，移除 conformance 相关的默认设置
+	// 目前使用 clang-cl.exe ，所以参数格式为 /std:c++20 而非 -std=c++20
 	switch langStd {
 	case "stdcpplatest":
-		return "-std=c++20"
+		return "/std:c++20"
 	case "stdcpp20":
-		return "-std=c++20"
+		return "/std:c++20"
 	case "stdcpp17":
-		return "-std=c++17"
+		return "/std:c++17"
 	case "stdcpp14":
-		return "-std=c++14"
+		return "/std:c++14"
 	case "stdcpp11":
-		return "-std=c++11"
+		return "/std:c++11"
 	}
-	return "-std=c++20"
+	return "/std:c++20"
 }

--- a/sln/sln.go
+++ b/sln/sln.go
@@ -75,7 +75,7 @@ func (sln *Sln) CompileCommandsJson(conf string) ([]CompileCommand, error) {
 			item.Dir = pro.ProjectDir
 			item.File = f
 
-			inc, def, err := pro.FindConfig(conf)
+			inc, def, cppStd, err := pro.FindConfig(conf)
 			if err != nil {
 				return cmdList, err
 			}
@@ -93,12 +93,15 @@ func (sln *Sln) CompileCommandsJson(conf string) ([]CompileCommand, error) {
 			inc = RemoveBadInclude(inc)
 			inc = preappend(inc, "-I")
 
-			cmd := "clang-cl.exe " + def + " " + inc + " -c " + f
+			cmd := "clang-cl.exe"
+			if cppStd != "" {
+				cmd += " " + cppStd
+			}
+			cmd += " " + def + " " + inc + " -c " + f
 			item.Cmd = cmd
 
 			cmdList = append(cmdList, item)
 		}
-
 	}
 	return cmdList, nil
 }


### PR DESCRIPTION
写挺杂的，或许上游有用呢。